### PR TITLE
Android API level 19

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,8 +89,8 @@ eclipse {
     }
 
     jdt {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = 1.6
+        targetCompatibility = 1.6
     }
 
     classpath {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
     }
     defaultConfig {
         applicationId "mmorihiro.matchland"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     }
     
     repositories {
-        mavenLocal()
         mavenCentral()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
@@ -30,7 +29,6 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "mmorihiro.matchland.desktop.DesktopLauncher"


### PR DESCRIPTION
- 開発PCに残っているキャッシュがバグの原因になることがあるので`mavenLocal()`を削除
- AndroidはJava 1.6ベースなので`sourceCompatibility`を1.6に(今は動いてるけど一応)
- Androidで動作するバージョンをAPI level 21(Android 5.0)からAPI level 19(Android 4.4)に戻す(Android 4.4でも動作確認できたので)